### PR TITLE
Update black to 22.3.0 (#19)

### DIFF
--- a/{{cookiecutter.repo_name}}/Pipfile
+++ b/{{cookiecutter.repo_name}}/Pipfile
@@ -9,7 +9,7 @@ python_version = "{python_version}"
 [packages]
 
 [dev-packages]
-black = "==20.8b1"
+black = "==22.3.0"
 flake8 = "*"
 isort = "*"
 mypy = "*"


### PR DESCRIPTION
- Previous version of black was incompatible with newer versions of click